### PR TITLE
fix: forces rendering update from new props

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,19 @@ import nouislider from 'nouislider-algolia-fork';
 
 class Nouislider extends React.Component {
   componentDidMount() {
+    this.createSlider();
+  }
+
+  componentDidUpdate() {
+    this.slider.destroy();
+    this.createSlider();
+  }
+
+  componentWillUnmount() {
+    this.slider.destroy();
+  }
+
+  createSlider() {
     var slider = this.slider = nouislider.create(this.sliderContainer, {...this.props});
 
     if (this.props.onUpdate) {
@@ -12,15 +25,6 @@ class Nouislider extends React.Component {
     if (this.props.onChange) {
       slider.on('change', this.props.onChange);
     }
-  }
-
-  componentWillReceiveProps(props) {
-    this.slider.updateOptions({...this.props});
-    this.slider.set(props.start);
-  }
-
-  componentWillUnmount() {
-    this.slider.destroy();
   }
 
   render() {


### PR DESCRIPTION
When updating the ranges, the pips are not updated. With this PR (which based on recommendation from the [noUiSlider website](http://refreshless.com/nouislider/more/#section-update)) it forces a complete re-rendering of the whole component.
