### PR TITLE
chore(proptypes): use prop-types instead of bundled

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -12,5 +12,6 @@ ReactDOM.render(
     range={{min: 0, max: 200}}
     start={[0, 100]}
     tooltips
-  />, document.querySelector('#container')
+  />,
+  document.querySelector('#container')
 );

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import nouislider from 'nouislider';
 
@@ -20,7 +21,9 @@ class Nouislider extends React.Component {
   }
 
   createSlider() {
-    var slider = this.slider = nouislider.create(this.sliderContainer, {...this.props});
+    var slider = (this.slider = nouislider.create(this.sliderContainer, {
+      ...this.props
+    }));
 
     if (this.props.onUpdate) {
       slider.on('update', this.props.onUpdate);
@@ -48,58 +51,61 @@ class Nouislider extends React.Component {
   }
 
   render() {
-    return <div ref={slider => {this.sliderContainer = slider;}} />;
+    return (
+      <div
+        ref={slider => {
+          this.sliderContainer = slider;
+        }}
+      />
+    );
   }
 }
 
 Nouislider.propTypes = {
   // http://refreshless.com/nouislider/slider-options/#section-animate
-  animate: React.PropTypes.bool,
+  animate: PropTypes.bool,
   // http://refreshless.com/nouislider/behaviour-option/
-  behaviour: React.PropTypes.string,
+  behaviour: PropTypes.string,
   // http://refreshless.com/nouislider/slider-options/#section-Connect
-  connect: React.PropTypes.oneOfType([
-    React.PropTypes.arrayOf(React.PropTypes.bool),
-    React.PropTypes.bool
-  ]),
+  connect: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.bool), PropTypes.bool]),
   // http://refreshless.com/nouislider/slider-options/#section-cssPrefix
-  cssPrefix: React.PropTypes.string,
+  cssPrefix: PropTypes.string,
   // http://refreshless.com/nouislider/slider-options/#section-orientation
-  direction: React.PropTypes.oneOf(['ltr', 'rtl']),
+  direction: PropTypes.oneOf(['ltr', 'rtl']),
   // http://refreshless.com/nouislider/more/#section-disable
-  disabled: React.PropTypes.bool,
+  disabled: PropTypes.bool,
   // http://refreshless.com/nouislider/slider-options/#section-limit
-  limit: React.PropTypes.number,
+  limit: PropTypes.number,
   // http://refreshless.com/nouislider/slider-options/#section-margin
-  margin: React.PropTypes.number,
+  margin: PropTypes.number,
   // http://refreshless.com/nouislider/events-callbacks/#section-change
-  onChange: React.PropTypes.func,
+  onChange: PropTypes.func,
   // http://refreshless.com/nouislider/events-callbacks/
-  onEnd: React.PropTypes.func,
+  onEnd: PropTypes.func,
   // http://refreshless.com/nouislider/events-callbacks/#section-set
-  onSet: React.PropTypes.func,
+  onSet: PropTypes.func,
   // http://refreshless.com/nouislider/events-callbacks/#section-slide
-  onSlide: React.PropTypes.func,
+  onSlide: PropTypes.func,
   // http://refreshless.com/nouislider/events-callbacks/
-  onStart: React.PropTypes.func,
+  onStart: PropTypes.func,
   // http://refreshless.com/nouislider/events-callbacks/#section-update
-  onUpdate: React.PropTypes.func,
+  onUpdate: PropTypes.func,
   // http://refreshless.com/nouislider/slider-options/#section-orientation
-  orientation: React.PropTypes.oneOf(['horizontal', 'vertical']),
+  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
   // http://refreshless.com/nouislider/pips/
-  pips: React.PropTypes.object,
+  pips: PropTypes.object,
   // http://refreshless.com/nouislider/slider-values/#section-range
-  range: React.PropTypes.object.isRequired,
+  range: PropTypes.object.isRequired,
   // http://refreshless.com/nouislider/slider-options/#section-start
-  start: React.PropTypes.arrayOf(React.PropTypes.number).isRequired,
+  start: PropTypes.arrayOf(PropTypes.number).isRequired,
   // http://refreshless.com/nouislider/slider-options/#section-step
-  step: React.PropTypes.number,
+  step: PropTypes.number,
   // http://refreshless.com/nouislider/slider-options/#section-tooltips
-  tooltips: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.arrayOf(
-      React.PropTypes.shape({
-        to: React.PropTypes.func
+  tooltips: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.arrayOf(
+      PropTypes.shape({
+        to: PropTypes.func
       })
     )
   ])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-nouislider",
-  "version": "2.0.0",
+  "version": "2.0.1-beta.0",
   "description": "React component wrapping leongersen/noUiSlider",
   "main": "dist/react-nouislider.common.js",
   "scripts": {
@@ -27,7 +27,8 @@
     "url": "https://github.com/algolia/react-nouislider/issues"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.1"
+    "prop-types": "^15.6.0",
+    "react": "^0.14.0 || ^15.0.1 || ^16.0.0"
   },
   "homepage": "https://github.com/algolia/react-nouislider",
   "dependencies": {
@@ -43,8 +44,8 @@
     "eslint-config-algolia": "^4.6.0",
     "eslint-plugin-algolia": "^1.5.0",
     "eslint-plugin-react": "^3.16.1",
-    "react": "^15.0.2",
-    "react-dom": "^15.0.2",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.12.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1037,9 +1037,9 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.1, fbjs@^0.8.4:
-  version "0.8.9"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.9.tgz#180247fbd347dcc9004517b904f865400a0c8f14"
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -1876,7 +1876,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2074,7 +2074,7 @@ object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2254,6 +2254,14 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proxy-addr@~1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.3.tgz#dc97502f5722e888467b3fa2297a7b1ff47df074"
@@ -2317,21 +2325,23 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^15.0.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
+react-dom@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
   dependencies:
-    fbjs "^0.8.1"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
-react@^15.0.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
+react@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.1.0, readable-stream@^2.2.2:
   version "2.2.3"


### PR DESCRIPTION
fixes #39 

You can try this out by doing: 

```sh
$ yarn add react-nouislider@2.0.1-beta.0
```